### PR TITLE
Apply allow attribute to a statement, not an expr

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The syntax proposed in the RFC was `if !let PAT = EXPR { BODY }` or `let PAT = E
 ## Examples
 
 ```rust
-#![cfg_attr(feature = "nightly", feature(stmt_expr_attributes)]
 #[macro_use] extern crate guard;
 use std::env;
 
@@ -24,11 +23,7 @@ fn main() {
 
 ## Cargo features
 
-- `nightly` enables nightly tests and uses expression attributes in the expansion (see [RFC 16](https://github.com/rust-lang/rfcs/pull/16)).
-
-  Requires `#![feature(stmt_expr_attributes)]` in the client crate.
-
-  Without this feature enabled, you will get two `unreachable_code` warnings on each invocation of the macro when using a nightly compiler.
+- `nightly` was historically required to avoid warnings when compiling with a nightly compiler. It now does nothing and is kept around only for backwards-compatibility purposes.
 - `debug` enables `trace_macros` for debugging. Requires a nightly compiler (but not this crate's `nightly` feature).
 
 ## How it works


### PR DESCRIPTION
This works around the lack of expression attributes by placing it on the
surrounding block instead. This means that the 'nightly' feature is no
longer needed. I left it in place so as not to break users; I'll leave
that up to the owner's judgment whether you want to make a breaking
change or not (or alternatively, emit a warning that the feature is no
longer needed).

Tested with `cargo +stable test` and `cargo +nightly test`.